### PR TITLE
version: update output of -v/--version flag

### DIFF
--- a/args.go
+++ b/args.go
@@ -71,7 +71,10 @@ func (a *binArgs) parse(args []string) (string, error) {
 	}
 
 	if a.Version {
-		out := fmt.Sprintf("cronner v%s built with %s\nCopyright 2015 PagerDuty, Inc.; released under the BSD 3-Clause License\n", Version, runtime.Version())
+		out := fmt.Sprintf(
+			"cronner v%s built with %s\nCopyright 2016 Tim Heckman\nCopyright 2015 PagerDuty, Inc.\nReleased under the BSD 3-Clause License\n",
+			Version, runtime.Version(),
+		)
 		return out, nil
 	}
 

--- a/args_test.go
+++ b/args_test.go
@@ -64,7 +64,7 @@ func (t *TestSuite) Test_binArgs_parse(c *C) {
 		"-V",
 	}
 
-	verOut := fmt.Sprintf("cronner v%s built with %s\nCopyright 2015 PagerDuty, Inc.; released under the BSD 3-Clause License\n", Version, runtime.Version())
+	verOut := fmt.Sprintf("cronner v%s built with %s\nCopyright 2016 Tim Heckman\nCopyright 2015 PagerDuty, Inc.\nReleased under the BSD 3-Clause License\n", Version, runtime.Version())
 
 	output, err = args.parse(cli)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
This change updates the output of the `-v/--version` flag to include the
`Copyright 2016 Tim Heckman` notice.