### PR TITLE
use a better method for trimming a network read buffer

### DIFF
--- a/cronner_test.go
+++ b/cronner_test.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"math/rand"
 	"net"
@@ -100,13 +99,13 @@ func listener(l *net.UDPConn, ctrl <-chan int, c chan<- []byte) {
 		default:
 			buffer := make([]byte, 8193)
 
-			_, err := l.Read(buffer)
+			n, err := l.Read(buffer)
 
 			if err != nil {
 				continue
 			}
 
-			c <- bytes.Trim(buffer, "\x00")
+			c <- buffer[:n]
 		}
 	}
 }


### PR DESCRIPTION
`cronner` was written when I was a bit more naïve when it came to Go. Back then
I didn't consider creating a subslice of the buffer, when reading from a UDP
stream, to trim off the nil bytes, and instead used `bytes.Trim()`.

This change removes the call to `bytes.Trim()` and instead trims the byte slice
down by creating a subslice (`buffer[:n]`).

Signed-off-by: Tim Heckman <t@heckman.io>