### PR TITLE
use const for version string; update copyright to include 2017

### DIFF
--- a/args.go
+++ b/args.go
@@ -1,4 +1,5 @@
-// Copyright 2015 PagerDuty, Inc, et al. All rights reserved.
+// Copyright 2015 PagerDuty, Inc., et al.
+// Copyright 2016-2017 Tim Heckman
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
@@ -14,6 +15,13 @@ import (
 	"github.com/jessevdk/go-flags"
 	"github.com/tideland/golib/logger"
 )
+
+// appVersionString is the full version string for the -V/--version output
+const appVersionString = `cronner v%s built with %s
+Copyright 2015 PagerDuty, Inc.
+Copyright 2016-2017 Tim Heckman
+Released under the BSD 3-Clause License
+`
 
 // binArgs is for argument parsing
 type binArgs struct {
@@ -72,7 +80,7 @@ func (a *binArgs) parse(args []string) (string, error) {
 
 	if a.Version {
 		out := fmt.Sprintf(
-			"cronner v%s built with %s\nCopyright 2016 Tim Heckman\nCopyright 2015 PagerDuty, Inc.\nReleased under the BSD 3-Clause License\n",
+			appVersionString,
 			Version, runtime.Version(),
 		)
 		return out, nil

--- a/args_test.go
+++ b/args_test.go
@@ -1,4 +1,5 @@
-// Copyright 2015 PagerDuty, Inc, et al. All rights reserved.
+// Copyright 2015 PagerDuty, Inc., et al.
+// Copyright 2016-2017 Tim Heckman
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
@@ -64,7 +65,7 @@ func (t *TestSuite) Test_binArgs_parse(c *C) {
 		"-V",
 	}
 
-	verOut := fmt.Sprintf("cronner v%s built with %s\nCopyright 2016 Tim Heckman\nCopyright 2015 PagerDuty, Inc.\nReleased under the BSD 3-Clause License\n", Version, runtime.Version())
+	verOut := fmt.Sprintf("cronner v%s built with %s\nCopyright 2015 PagerDuty, Inc.\nCopyright 2016-2017 Tim Heckman\nReleased under the BSD 3-Clause License\n", Version, runtime.Version())
 
 	output, err = args.parse(cli)
 	c.Assert(err, IsNil)

--- a/cronner.go
+++ b/cronner.go
@@ -1,4 +1,5 @@
-// Copyright 2015 PagerDuty, Inc, et al. All rights reserved.
+// Copyright 2015 PagerDuty, Inc, et al.
+// Copyright 2016-2017 Tim Heckman
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 

--- a/cronner_test.go
+++ b/cronner_test.go
@@ -1,4 +1,5 @@
-// Copyright 2015 PagerDuty, Inc, et al. All rights reserved.
+// Copyright 2015 PagerDuty, Inc., et al.
+// Copyright 2016-2017 Tim Heckman
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 

--- a/runner.go
+++ b/runner.go
@@ -1,4 +1,5 @@
-// Copyright 2015 PagerDuty, Inc, et al. All rights reserved.
+// Copyright 2015 PagerDuty, Inc., et al.
+// Copyright 2016-2017 Tim Heckman
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -1,12 +1,13 @@
-// Copyright 2015 PagerDuty, Inc, et al. All rights reserved.
+// Copyright 2015 PagerDuty, Inc., et al.
+// Copyright 2016-2017 Tim Heckman
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
 package main
 
 import (
-	"fmt"
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"


### PR DESCRIPTION
This changes the application version string to use a constant raw literal
instead of a single large line with `\n` to break the newlines.

This also updates the copyright for Tim Heckman to range from 2016-2017.

Signed-off-by: Tim Heckman <t@heckman.io>