### PR TITLE
add support for linking jobs running within cronner

### DIFF
--- a/args.go
+++ b/args.go
@@ -39,6 +39,7 @@ type binArgs struct {
 	LogLevel    string   `short:"L" long:"log-level" default:"error" description:"set the level at which to log at [none|error|info|debug]"`
 	Namespace   string   `short:"N" long:"namespace" default:"cronner" description:"namespace for statsd emissions, value is prepended to metric name by statsd client"`
 	Passthru    bool     `short:"p" long:"passthru" description:"passthru stdout/stderr to controlling tty"`
+	Parent      bool     `short:"P" long:"use-parent" description:"if cronner invocation is runner under cronner, emit the parental values as tags"`
 	Sensitive   bool     `short:"s" long:"sensitive" description:"specify whether command output may contain sensitive details, this only avoids it being printed to stderr"`
 	Version     bool     `short:"V" long:"version" description:"print the version string and exit"`
 	WarnAfter   uint64   `short:"w" long:"warn-after" default:"0" value-name:"N" description:"emit a warning event every N seconds if the job hasn't finished, set to 0 to disable"`

--- a/args_test.go
+++ b/args_test.go
@@ -106,6 +106,7 @@ func (t *TestSuite) Test_binArgs_parse(c *C) {
 	c.Check(args.LogPath, Equals, "/var/log/cronner")
 	c.Check(args.LogLevel, Equals, "error")
 	c.Check(args.Namespace, Equals, "cronner")
+	c.Check(args.Parent, Equals, false)
 	c.Check(args.Passthru, Equals, false)
 	c.Check(args.Sensitive, Equals, false)
 	c.Check(args.Version, Equals, false)
@@ -128,6 +129,7 @@ func (t *TestSuite) Test_binArgs_parse(c *C) {
 		"-l", "test",
 		"-L", "info",
 		"-N", "testcronner",
+		"-P",
 		"-p",
 		"-s",
 		"-w", "42",
@@ -153,6 +155,7 @@ func (t *TestSuite) Test_binArgs_parse(c *C) {
 	c.Check(args.Label, Equals, "test")
 	c.Check(args.LogLevel, Equals, "info")
 	c.Check(args.Namespace, Equals, "testcronner")
+	c.Check(args.Parent, Equals, true)
 	c.Check(args.Passthru, Equals, true)
 	c.Check(args.Sensitive, Equals, true)
 	c.Check(args.Version, Equals, false)
@@ -178,6 +181,7 @@ func (t *TestSuite) Test_binArgs_parse(c *C) {
 		"--log-path", "/var/log/testcronner",
 		"--log-level", "info",
 		"--namespace", "testcronner",
+		"--use-parent",
 		"--passthru",
 		"--sensitive",
 		"--warn-after", "42",
@@ -201,6 +205,7 @@ func (t *TestSuite) Test_binArgs_parse(c *C) {
 	c.Check(args.LogPath, Equals, "/var/log/testcronner")
 	c.Check(args.LogLevel, Equals, "info")
 	c.Check(args.Namespace, Equals, "testcronner")
+	c.Check(args.Parent, Equals, true)
 	c.Check(args.Passthru, Equals, true)
 	c.Check(args.Sensitive, Equals, true)
 	c.Check(args.Version, Equals, false)

--- a/runner_test.go
+++ b/runner_test.go
@@ -295,6 +295,61 @@ func (t *TestSuite) Test_handleCommand(c *C) {
 	)
 
 	//
+	// Test that parent tags are emitted
+	//
+
+	// Reset variables used
+	r = nil
+	err = nil
+	runTime = 0
+	match = nil
+
+	t.h.cmd = exec.Command("/bin/echo", "somevalue")
+	t.h.opts.Group = "metricgroup"
+	t.h.opts.EventGroup = ""
+	t.h.opts.Parent = true
+	t.h.parentEventTags = []string{"cronner_parent_uuid:" + testCronnerUUID, "cronner_parent_event_group:testParentEventGroup"}
+	t.h.parentMetricTags = []string{"cronner_parent_group:testParentGroup", "cronner_parent_label:testParent"}
+
+	_, r, runTime, err = handleCommand(t.h)
+	c.Assert(err, IsNil)
+
+	stat, ok = <-t.out
+	c.Assert(ok, Equals, true)
+	c.Check(
+		string(stat),
+		Equals,
+		fmt.Sprintf(
+			`_e{35,44}:Cron testCmd starting on brainbox01|UUID: %v\n|k:%v|s:cronner|t:info|#source_type:cronner,cronner_label_name:testCmd,cronner_parent_uuid:%s,cronner_parent_event_group:testParentEventGroup`,
+			t.h.uuid, t.h.uuid, testCronnerUUID,
+		),
+	)
+
+	stat, ok = <-t.out
+	c.Assert(ok, Equals, true)
+	timeStatTagRegex = regexp.MustCompile("^cronner.testCmd.time:([0-9\\.]+)\\|ms\\|#cronner_group:([a-z]+),cronner_parent_group:testParentGroup,cronner_parent_label:testParent$")
+	match = timeStatTagRegex.FindAllStringSubmatch(string(stat), -1)
+	c.Assert(len(match), Equals, 1)
+	c.Assert(len(match[0]), Equals, 3)
+	c.Check(strconv.FormatFloat(runTime, 'f', -1, 64), Equals, match[0][1])
+	c.Check("metricgroup", Equals, match[0][2])
+
+	stat, ok = <-t.out
+	c.Assert(ok, Equals, true)
+	c.Check(string(stat), Equals, "cronner.testCmd.exit_code:0|g|#cronner_group:metricgroup,cronner_parent_group:testParentGroup,cronner_parent_label:testParent")
+
+	stat, ok = <-t.out
+	c.Assert(ok, Equals, true)
+	c.Check(
+		string(stat),
+		Equals,
+		fmt.Sprintf(
+			`_e{55,77}:Cron testCmd succeeded in %.5f seconds on brainbox01|UUID: %v\nexit code: 0\noutput: somevalue\n|k:%v|s:cronner|t:success|#source_type:cronner,cronner_label_name:testCmd,cronner_parent_uuid:%s,cronner_parent_event_group:testParentEventGroup`,
+			runTime/1000, t.h.uuid, t.h.uuid, testCronnerUUID,
+		),
+	)
+
+	//
 	// Test that no output is given
 	//
 
@@ -311,6 +366,10 @@ func (t *TestSuite) Test_handleCommand(c *C) {
 	t.h.opts.LogFail = false
 	t.h.opts.Lock = true
 	t.h.opts.AllEvents = false
+	t.h.opts.Parent = false
+
+	t.h.parentEventTags = nil
+	t.h.parentMetricTags = nil
 
 	retCode, r, _, err = handleCommand(t.h)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
This change makes an alteration to `cronner` which injects environment variables
to let subprocesses know they are running inside of `cronner`.

In addition to the change above, a new flag (`-P/--use-parent`) was added to
instruct `cronner` to slurp the environment variables set by the parent cronner
and emit the relevant tags with the events and metrics.

`cronner` now sets the following environment variables before invoking a
command:

* `CRONNER_PARENT_UUID`: this is the UUID of the parent `cronner` job; use this
  environment variable to determine if cronner is invoking you
* `CRONNER_PARENT_EVENT_GROUP`: this is the event group tag `cronner` is using
* `CRONNER_PARENT_GROUP`: this is the group tag `cronner` is emitting metrics
  with
* `CRONNER_PARENT_NAMESPACE`: the namespace of the parent invocation
* `CRONNER_PARENT_LABEL`: the label of the parent invocation

For events `cronner` will emit the following parent tags:

* `cronner_parent_uuid` and `cronner_parent_event_group`

For metrics `cronner` will emit the following parent tags:

* `cronner_parent_group`
* `cronner_parent_namespace`
* `cronner_parent_label`

Signed-off-by: Tim Heckman <t@heckman.io>