### PR TITLE
build cronner against Go 1.7.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.7.4
+- 1.7.5
 addons:
   apt:
     packages:


### PR DESCRIPTION
Go 1.7.5 was a bugfix release, so may as well build `cronner` against it to make
sure we're as stable as possible. I'm unaware of any of the fixed bugs impacting
any invocations of `cronner`.

Signed-off-by: Tim Heckman <t@heckman.io>