### PR TITLE
Add support for additional tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Application Options:
   -p, --passthru                   passthru stdout/stderr to controlling tty
   -P, --use-parent                 if cronner invocation is runner under cronner, emit the parental values as tags
   -s, --sensitive                  specify whether command output may contain sensitive details, this only avoids it being printed to stderr
+  -t, --tag=                       additional tags to add to datadog events and metrics (can be used multiple times), either <key>:<value> or <string> format
   -V, --version                    print the version string and exit
   -w, --warn-after=N               emit a warning event every N seconds if the job hasn't finished, set to 0 to disable (default: 0)
   -W, --wait-secs=                 how long to wait for the file lock for (default: 0)

--- a/cronner.go
+++ b/cronner.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Version is the program's version string
-const Version = "0.6.1"
+const Version = "0.7.0"
 
 type cmdHandler struct {
 	gs               *godspeed.Godspeed

--- a/runner.go
+++ b/runner.go
@@ -238,6 +238,10 @@ func handleCommand(hndlr *cmdHandler) (int, []byte, float64, error) {
 		tags = append(tags, hndlr.parentMetricTags...)
 	}
 
+	if len(hndlr.opts.Tags) > 0 {
+		tags = append(tags, hndlr.opts.Tags...)
+	}
+
 	hndlr.gs.Timing(fmt.Sprintf("%v.time", hndlr.opts.Label), monotonicRtMs, tags)
 	hndlr.gs.Gauge(fmt.Sprintf("%v.exit_code", hndlr.opts.Label), float64(ret), tags)
 
@@ -335,6 +339,10 @@ func emitEvent(title, body, label, alertType string, hndlr *cmdHandler) {
 
 	if hndlr.opts.Parent && len(hndlr.parentEventTags) > 0 {
 		tags = append(tags, hndlr.parentEventTags...)
+	}
+
+	if len(hndlr.opts.Tags) > 0 {
+		tags = append(tags, hndlr.opts.Tags...)
 	}
 
 	hndlr.gs.Event(title, body, fields, tags)


### PR DESCRIPTION
This PR proposes supporting additional tags to include with dogstatsd metrics and events. Additional tags can be included with the `-t` or `--tag` cli argument, this option can be specified multiple times.

Any included tags are validated against the [dogstatsd tag specification](http://docs.datadoghq.com/guides/metrics/#tags) prior to executing the command.

Please let me know if you have any feedback!