### PR TITLE
Update Travis CI configuration to build against go1.8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.7.5
+- 1.8.3
 addons:
   apt:
     packages:


### PR DESCRIPTION
This is a maintenance task to prep a cronner release built against a newer
Golang runtime. There have been no reported issues to prompt this change, and is
only a bit of housekeeping.