### PR TITLE
Update tests / build to use Go 1.10.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.9
+- 1.10.4
 addons:
   apt:
     packages:


### PR DESCRIPTION
It's not using Go 1.11 because of some critical bugs due to be fixed in 1.11.1.

Signed-off-by: Tim Heckman <t@heckman.io>