### PR TITLE
Update release configuration with new credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,21 +10,21 @@ notifications:
   email:
     on_success: never
     on_failure: always
-env: 'PROJECT_NAME=cronner GOARCH=amd64 GOOS=linux PROJECT_BUILD_NAME="$PROJECT_NAME-$GOOS-$GOARCH-$TRAVIS_TAG"'
+env: PROJECT_NAME=cronner GOARCH=amd64 GOOS=linux PROJECT_BUILD_NAME="$PROJECT_NAME-$GOOS-$GOARCH-$TRAVIS_TAG"
 install: true
 before_script:
-  - rm -rf  ${GOPATH}/pkg/*
+- rm -rf  ${GOPATH}/pkg/*
 script: make test
 before_deploy:
 - make prep-deploy
 deploy:
   provider: releases
   skip_cleanup: true
+  api_key:
+    secure: sGH346h2W9xXsMY4LT5XOUNUukeQ7JwqMaMyDjC5mVkwkVGDczx/TLzzcPFKL51kYIjbma4OefZ8XTD1x62GHIsJSbgcVgjKabqbjaSivMajlDnn5X0v7cBv4bKwvwb7f1RiszVBNM7fK1GjWFvpCjPEE28MLyVVNZVb7C7gkBhKfSKwYcv222aJIh/pV1JBgo9riAI5uvgfMIuaLlq0Ni+WvvapC087t9RvRsVade1vX/yrYNNwhctA00qclT6CezpCR/MPOZXfQiUQcnvhRc4ypziX89psK7PF925w6kgTQ6Od/TSeFxb0zg/JYjemqwRp8LE+zHt3smmwtRoTf0JRsPyvSxsm6pzHFi37HiRDqVQXeiQvSNk77jhwZcGMcPli5l1HG/A1X6zf2Mzbu5e0qtt4sOsefh/MU1p5KK38HIZhDSgwsUChsihbIq1MGhrxciw6Upj1B5bt7D+/NAeJtlToxsL08WmwTKElCrfHh71LCL64aMahtqAvEudqwM1n5WBnGsomyIIZh5jC46d1z7a5tfLZgiLsLaGHZ2qr4QPj//OUjzGklSklxlsQpCImqf81PE6M8lp/ksyquhOHWjWsmfSSBYl7BtC+t93PrlliMokXbTfWnO8tkPM+qaVfeC0Uc2GS50McjbC5BambYirxXPrEL28hji5dlAQ=
   file:
   - build/$PROJECT_BUILD_NAME.tar.gz
   - build/$PROJECT_BUILD_NAME.tar.gz.sha256
   on:
     repo: theckman/cronner
     tags: true
-  api_key:
-    secure: BYFoIL6jJi/OAK/GMiMyHE75ESHSTgvD4kV4WxMvsgeFyJc8X9svRPV845nGo+tbtxtQOqPs3jOyRqbAI/Snuv0b1MUCCpAkNJZn4kc63gQHt79ebSuv58hov3WJrL3S0Pv6lQLqwHAmotRmGl+FvRpS8QxLT4NJsbYFRsCIzv93Aia3+2+NX2xT8p3IE46WI5eZXUPeQ/u3MqKosbi/soYWdY5bybA0vIyio4zcoDZqEb7q88lTlrGA4tkEtzad37PSWjnMguBGtbOsHoZH3vHLYmWdVa2Rsb9Cf54LTvp6d72bKbS9bcIwHw7JBlwDKGQF+sG763prxtHEdvO4hSUOfRH5fOhvFB+JNAt/mPqyTbUhEp6sgfAikJ6BARawhU6HWdKMPAoD5OB3+GFF/hzbWCFrxvSpmxC1QuWNUALwbaPOJEIKfyJ6hMwAIUqKqUEfDfE8hIruW6PSaw2oyfQghQCLPVCetxZh0D0sqFV3M499OSj/UYt51H8o4NvooMTQTO0Dl/tXl8S4UNtXJSRGmMyTlOVOvoNzo6Z8M4e7L7suwwHX2XLe72M764F0izDxpvD2gSz3VsjsZ61xjzupkpVu9Q2AEOY5dvKEimPucq6b8n/QHRd2SFltsFTPP/bsQKd+QBbFVonOhgC91b7paV6W0E91PEBsmCl66JI=


### PR DESCRIPTION
The old credentials were revoked, so let's add new ones. This was generated with
`travis setup releases --force`.

Fixes #24

Signed-off-by: Tim Heckman <t@heckman.io>