### PR TITLE
Add command line flag to specify statsd port

### DIFF
--- a/args.go
+++ b/args.go
@@ -35,6 +35,7 @@ type binArgs struct {
 	Group       string   `short:"g" long:"group" value-name:"<group>" description:"emit a cronner_group:<group> tag with statsd metrics"`
 	EventGroup  string   `short:"G" long:"event-group" value-name:"<group>" description:"emit a cronner_group:<group> tag with Datadog events, does not get sent with statsd metrics"`
 	StatsdHost  string   `short:"H" long:"statsd-host" value-name:"<host>" description:"destination host to send datadog metrics"`
+	StatsdPort  int      `long:"statsd-port" value-name:"<port>" description:"destination port to send datadog metrics"`
 	Lock        bool     `short:"k" long:"lock" description:"lock based on label so that multiple commands with the same label can not run concurrently"`
 	Label       string   `short:"l" long:"label" description:"name for cron job to be used in statsd emissions and DogStatsd events. alphanumeric only; cronner will lowercase it"`
 	LogPath     string   `long:"log-path" default:"/var/log/cronner" description:"where to place the log files for command output (path for -F/--log-fail output)"`

--- a/args_test.go
+++ b/args_test.go
@@ -185,6 +185,7 @@ func (t *TestSuite) Test_binArgs_parse(c *C) {
 		"--event-group", "test_group",
 		"--group", "metric_group",
 		"--statsd-host", "test_host",
+		"--statsd-port", "8127",
 		"--lock",
 		"--label", "test",
 		"--log-path", "/var/log/testcronner",
@@ -212,6 +213,7 @@ func (t *TestSuite) Test_binArgs_parse(c *C) {
 	c.Check(args.EventGroup, Equals, "test_group")
 	c.Check(args.Group, Equals, "metric_group")
 	c.Check(args.StatsdHost, Equals, "test_host")
+	c.Check(args.StatsdPort, Equals, int(8127))
 	c.Check(args.Lock, Equals, true)
 	c.Check(args.Label, Equals, "test")
 	c.Check(args.LogPath, Equals, "/var/log/testcronner")
@@ -239,6 +241,7 @@ func (t *TestSuite) Test_binArgs_parse(c *C) {
 		"--event-group=test_group",
 		"--group=metric_group",
 		"--statsd-host=test_host",
+		"--statsd-port=8127",
 		"--label=test",
 		"--log-path=/var/log/testcronner",
 		"--log-level=info",
@@ -259,6 +262,7 @@ func (t *TestSuite) Test_binArgs_parse(c *C) {
 	c.Check(args.EventGroup, Equals, "test_group")
 	c.Check(args.Group, Equals, "metric_group")
 	c.Check(args.StatsdHost, Equals, "test_host")
+	c.Check(args.StatsdPort, Equals, int(8127))
 	c.Check(args.Label, Equals, "test")
 	c.Check(args.LogPath, Equals, "/var/log/testcronner")
 	c.Check(args.LogLevel, Equals, "info")

--- a/cronner.go
+++ b/cronner.go
@@ -97,11 +97,20 @@ func main() {
 
 	// build a Godspeed client
 	var gs *godspeed.Godspeed
-	if opts.StatsdHost == "" {
-		gs, err = godspeed.NewDefault()
-	} else {
-		gs, err = godspeed.New(opts.StatsdHost, godspeed.DefaultPort, false)
+
+	var StatsdHost string
+	StatsdHost = godspeed.DefaultHost
+	if opts.StatsdHost != "" {
+		StatsdHost = opts.StatsdHost
 	}
+
+	var StatsdPort int
+	StatsdPort = godspeed.DefaultPort
+	if opts.StatsdPort != 0 {
+		StatsdPort = opts.StatsdPort
+	}
+
+	gs, err = godspeed.New(StatsdHost, StatsdPort, false)
 
 	// make sure nothing went wrong with Godspeed
 	if err != nil {


### PR DESCRIPTION
For not great reasons, I have dogstatsd running on a nonstandard port. This change adds the --statsd-port command line flag to allow that port to be configurable in cronner. I did not add a short version for the option because both -p and -P were already taken.

Thank you for maintaining this tool!